### PR TITLE
Fix confusing single-date labels on transition figures

### DIFF
--- a/src/reporting/reporting.py
+++ b/src/reporting/reporting.py
@@ -23,6 +23,7 @@ from src.visualize_transitions import (
     collect_transition_estimates,
     compute_city_deviations,
     compute_city_aggregate_deviation,
+    load_election_dates,
     plot_all_cities_aggregate_deviation_subplots,
     plot_transition_matrix_over_elections,
 )
@@ -287,6 +288,8 @@ def _create_mad_table_lens(
     if per_pair_mad.empty:
         return None
 
+    election_dates = load_election_dates()
+
     # Get all cities from the data
     all_cities = per_pair_mad["city"].unique().tolist()
 
@@ -329,6 +332,13 @@ def _create_mad_table_lens(
 
     for i, pair in enumerate(transition_pairs):
         ax = axes[i]
+
+        # Parse pair tag (e.g., "kn19_20") to extract Knesset numbers
+        parts = pair.replace("kn", "").split("_")
+        kn_start, kn_end = int(parts[0]), int(parts[1])
+        date_start = election_dates.get(kn_start, f"Kn{kn_start}")
+        date_end = election_dates.get(kn_end, f"Kn{kn_end}")
+        ax.set_title(f"{kn_start}\u2192{kn_end}\n({date_start}\u2013{date_end})", fontsize=10)
 
         # Filter data for this pair
         pair_data = per_pair_mad[per_pair_mad["pair_tag"] == pair].copy()

--- a/src/visualize_transitions.py
+++ b/src/visualize_transitions.py
@@ -180,6 +180,32 @@ def set_xlabel(ax: plt.Axes, label: str = None) -> None:
     ax.set_xlabel(label, rotation=0, ha="right", va="top", x=1)
 
 
+def add_date_secondary_axis(ax: plt.Axes, election_dates: Dict[int, str], fontsize: int = 8) -> plt.Axes:
+    """Add a secondary x-axis at the top showing date ranges for transitions.
+
+    Places date-range labels at midpoints between integer Knesset ticks.
+    """
+    ax2 = ax.twiny()
+    ax2.set_xlim(ax.get_xlim())
+
+    kn_ticks = [int(t) for t in ax.get_xticks() if t == int(t)]
+    if len(kn_ticks) < 2:
+        return ax2
+
+    mid_positions = []
+    mid_labels = []
+    for kn_start, kn_end in zip(kn_ticks[:-1], kn_ticks[1:]):
+        mid_positions.append((kn_start + kn_end) / 2)
+        d_start = election_dates.get(kn_start, "")
+        d_end = election_dates.get(kn_end, "")
+        mid_labels.append(f"{d_start}\u2013{d_end}")
+
+    ax2.set_xticks(mid_positions)
+    ax2.set_xticklabels(mid_labels, fontsize=fontsize, rotation=45, ha="left")
+    ax2.tick_params(axis="x", length=0)
+    return ax2
+
+
 def plot_transition_time_series(
     df_all: pd.DataFrame,
     from_category: str,
@@ -387,11 +413,13 @@ def plot_transition_matrix_over_elections(
         "Abstained": "Abstained",
     }
 
-    # Add column labels (from categories) at top
+    # Add column labels (from categories) at top, with secondary date axis
+    election_dates = load_election_dates()
     for j, from_cat in enumerate(CATEGORY_ORDER):
         ax = axes[0, j]  # Top row
         display_name = display_names.get(from_cat, from_cat)
-        ax.set_title(f"From: {display_name}", fontsize=12, pad=10)
+        ax.set_title(f"From: {display_name}", fontsize=12, pad=35)
+        add_date_secondary_axis(ax, election_dates, fontsize=7)
 
     # Add row labels (to categories) on left
     for i, to_cat in enumerate(CATEGORY_ORDER):
@@ -903,6 +931,10 @@ def plot_all_cities_aggregate_deviation_subplots(
             ax.set_xticks(np.arange(kn_min, kn_max + 1))
             ax.set_xlim(kn_min - 0.5, kn_max + 0.5)
 
+    # Add secondary date axis to top subplot
+    election_dates = load_election_dates()
+    add_date_secondary_axis(axes[0], election_dates, fontsize=8)
+
     # Add Hebrew x-label only to bottom subplot
     set_xlabel(axes[-1])
 
@@ -1209,17 +1241,18 @@ def plot_shas_shas_city_comparison(
             kn_start = int(np.floor(kn_location))
             kn_end = int(np.ceil(kn_location))
 
-            # Get date for the start knesset
+            # Get dates for both knesset numbers
             date_start = election_dates.get(kn_start, f"Kn{kn_start}")
+            date_end = election_dates.get(kn_end, f"Kn{kn_end}")
 
             # Position label at the kn_location
             x_pos = kn_location
 
-            # Add the label
+            # Add the label with both dates
             ax.text(
                 x_pos,
                 y_max,
-                f"#{kn_start}-{kn_end}\n{date_start}",
+                f"#{kn_start}\u2192{kn_end}\n{date_start}\u2013{date_end}",
                 ha="center",
                 va="bottom",
                 fontsize=14,

--- a/transition_paper/09_appendix.md
+++ b/transition_paper/09_appendix.md
@@ -60,9 +60,14 @@ Knesset 1920) were resolved by increasing the number of draws and adopting non-c
 
 ### Convergence Diagnostics
 
-| Transition | R-hat max | ESS min | |------|------------|----------| | Kn 1920 (Jan 2013Mar 2015) | 1.530 | 7 | | Kn
-2021 (Mar 2015Apr 2019) | 1.529 | 7 | | Kn 2122 (Apr 2019Sep 2019) | 1.465 | 7 | | Kn 2223 (Sep 2019Mar 2020) | 1.134 |
-19 | | Kn 2324 (Mar 2020Mar 2021) | 1.477 | 7 | | Kn 2425 (Mar 2021Nov 2022) | 1.737 | 6 |
+| Transition | R-hat max | ESS min |
+|------|------------|----------|
+| Kn 19-20 (Jan 2013 - Mar 2015) | 1.530 | 7 |
+| Kn 20-21 (Mar 2015 - Apr 2019) | 1.529 | 7 |
+| Kn 21-22 (Apr 2019 - Sep 2019) | 1.465 | 7 |
+| Kn 22-23 (Sep 2019 - Mar 2020) | 1.134 | 19 |
+| Kn 23-24 (Mar 2020 - Mar 2021) | 1.477 | 7 |
+| Kn 24-25 (Mar 2021 - Nov 2022) | 1.737 | 6 |
 
 While some early models show high R-hat and low ESS, these issues were largely addressed through increased sampling and
 refined priors. The final models show stable posteriors without divergences.


### PR DESCRIPTION
## Summary

- Figure 3 (shas_shas_city_comparison): labels now show both start and end election dates (e.g., "#23→24 Mar 2020–Mar 2021")
- 4x4 transition matrices: added secondary x-axis at top with date ranges, keeping bare Knesset numbers on bottom
- Cities aggregate deviation comparison: added secondary date axis on top subplot
- MAD table lens: added column headers identifying each transition pair with dates
- Appendix B diagnostics table: fixed broken single-line markdown into proper multi-row table

## Test plan

- [x] Visual inspection of regenerated `shas_shas_city_comparison.png`
- [x] Visual inspection of regenerated `country_transition_matrix_over_elections.png`
- [x] Visual inspection of regenerated `cities_aggregate_deviation_comparison.png`
- [x] Visual inspection of regenerated `mad_table_lens.png`
- [x] Appendix B table renders correctly in markdown preview

Closes #1