### PR TITLE
Cut repetition: eliminate four-fold restatement of core findings

### DIFF
--- a/transition_paper/01_intro.md
+++ b/transition_paper/01_intro.md
@@ -93,36 +93,11 @@ trends. The framework provides both national-level estimates and city-specific p
 centers.
 
 
-Three key findings emerge. First, Ashdod's 2021 segregation anomaly coincides precisely with a dramatic but temporary
-disruption in voter loyalty during the March 2020–March 2021 transition. Shas-to-Shas loyalty plummeted from 99% to 74%
-nationally (to 67% in Ashdod), with unprecedented cross-flows to UTJ. Critically, loyalty fully recovered by the next
-election (March 2021–November 2022), confirming that electoral switching, not residential movement, explained Ashdod's
-segregation drop. Second, this pattern of temporary disruption followed by complete recovery characterizes a rigid
-system experiencing stress fractures, not ongoing fluidity. The underlying ethnic-political boundaries remained intact
-despite the shock, challenging narratives of gradual erosion in identity-based voting. Third, geographic variation in
-disruption magnitude reveals how local contexts modulate boundary permeability: ethnically mixed cities like Ashdod
-showed larger temporary swings, while homogeneous strongholds like Bnei Brak remained more stable, yet all recovered
-fully.
-
-
-
-These findings have implications extending far beyond Israel. The pattern of temporary disruption followed by recovery, 
-what I term "rigidity with stress fractures", offers a new framework for understanding cohesive voting blocs globally.
-Rather than assuming either permanent stability or gradual erosion, this framework recognizes that strong institutional
-boundaries can temporarily yield under extraordinary pressure, then rapidly reconstitute. This insight applies to any
-democracy featuring identity-based voting blocs: from U.S. evangelicals to European regional parties to African ethnic
-coalitions. Israel's Haredi sector, as an extreme case of institutional discipline, provides a conservative test: if even
-this highly bounded community experiences measurable temporary volatility, similar dynamics likely operate, perhaps more
-strongly, in less institutionally rigid contexts.
-
-Methodologically, integrating spatial segregation metrics with temporal transition matrices offers a replicable framework
-for studying segmented populations. This pairing applies to immigrant communities divided by origin region, religious
-denominations within shared faith traditions, or linguistic minorities maintaining distinct political allegiances. By
-combining static measures (segregation at a point in time) with dynamic measures (transitions over time), researchers can
-quantify both the degree of separation and the rate of exchange between subgroups. The Ashdod anomaly also reveals a
-critical limitation: using voting patterns as proxies for residential segregation fails when political loyalty becomes
-unstable, with implications for any study conflating political and demographic boundaries.
-
+Three findings emerge: a nationwide collapse in voter loyalty during the March 2020–March 2021 transition, with
+substantial city-level variation in disruption magnitude, followed by rapid recovery that suggests temporary stress
+fractures rather than permanent realignment. This pattern, and its resolution of Ashdod's segregation anomaly through
+electoral switching rather than residential movement, carries implications for any democracy featuring identity-based
+voting blocs.
 
 Specifically, this study contributes by: (1) documenting temporary boundary permeability within an extreme-case
 disciplined bloc, providing a conservative estimate for volatility in identity-based voting; (2) grounding "rigidity

--- a/transition_paper/03_results.md
+++ b/transition_paper/03_results.md
@@ -167,33 +167,9 @@ values signal flux between parties or toward abstention.
 Two clusters emerge: highly stable cities (Jerusalem, Beit Shemesh, Ashdod) and relatively fluid ones (Elad, Modi'in
 Illit), possibly reflecting differences in demographic composition and institutional affiliations. The 23→24 disruption stands out as a clear outlier across all locations.
 
-## Summary of Findings
-
-The analysis yields six key findings about Haredi voter transition patterns:
-
-1. **Dominant pattern of high stability:** Across most election pairs, Shas and UTJ maintained loyalty rates above 95%,
-confirming the general portrait of Haredi voting as highly disciplined and predictable.
-
-2. **Sharp temporary disruption in the March 2020–March 2021 transition (23→24):** Shas loyalty dropped to 73.5%
-nationally (67.1% in Ashdod), with 12.3% switching to UTJ (19.3% in Ashdod). UTJ loyalty also fell to 87.9%, with
-4.6% of UTJ voters switching to Shas.
-
-3. **Full recovery in the March 2021–November 2022 transition (24→25):** Loyalty patterns returned to pre-crisis levels,
-indicating the disruption was temporary rather than a permanent realignment.
-
-4. **Geographic variation in disruption magnitude:** The 23→24 shock affected all cities but varied in intensity. Ashdod
-showed the largest deviations, followed by Bnei Brak and Beit Shemesh, suggesting that local demographic integration
-modulates electoral volatility.
-
-5. **Temporal proximity rules out demographic explanations:** The short intervals between elections (5.5–19 months)
-indicate genuine voter switching rather than migration or generational turnover.
-
-6. **Stable abstention rates:** Haredi participation remained resilient throughout, even during the 23→24 disruption,
-with minimal abstention flows contrasting with significant inter-party switching.
-
-These findings reveal that even highly cohesive voting blocs can experience rapid, system-wide disruptions in loyalty
-patterns that fully reverse when triggering conditions resolve. The consistency across cities points to a common
-underlying cause, while the variation in magnitude highlights how local conditions modulate the intensity of
-disruption within otherwise rigid structures. The Conclusions section explores the theoretical and methodological
-implications of these patterns, situating them within broader comparative frameworks and discussing their significance
-for understanding ethnic boundary maintenance in cohesive communities.
+Taken together, the transition matrices reveal a pattern of high baseline stability punctuated by a single, sharp
+disruption in the 23→24 transition that fully reversed by 24→25. The disruption affected all major Haredi population
+centers but varied in magnitude, with Ashdod showing the most extreme deviations. The short intervals between elections
+make demographic explanations implausible, pointing instead to genuine voter switching. The Conclusions section
+interprets these patterns within the "rigidity with stress fractures" framework and explores their theoretical and
+methodological implications.

--- a/transition_paper/04_conclusions.md
+++ b/transition_paper/04_conclusions.md
@@ -1,34 +1,11 @@
 # Conclusions
 
 
-The preceding Results section documented six key empirical findings about Haredi voter transitions: high baseline
-stability, a dramatic but temporary 23→24 disruption, full recovery by 24→25, geographic variation in disruption
-magnitude, temporal proximity ruling out demographic explanations, and stable abstention rates. This Conclusions section
-interprets these findings in theoretical and methodological context, exploring what they reveal about ethnic boundary
-maintenance, the conditions under which rigid voting blocs experience disruption, and the implications for measuring
-residential segregation through electoral proxies.
-
-### High Baseline Stability with Rare Disruptions
-
-The dominant pattern across the study period is one of exceptionally high intra-party loyalty. Shas and UTJ voters
-maintained loyalty rates exceeding 90% and 95% respectively in most elections, with cross-party transitions rarely
-exceeding 2 - 3% in either direction.
-
-However, this rigid structure experienced a dramatic temporary collapse during the March 2020–March 2021 transition
-(Knesset 23→24). Shas-to-Shas loyalty plummeted to 72.8% while Shas-to-UTJ switching surged to 12.3%. UTJ voters
-similarly experienced reduced loyalty (87.9%), with cross-flows to Shas. This represents the only substantive cross-party
-movement observed across all elections studied.
-
-
-Critically, this disruption proved temporary. By the subsequent March 2021–November 2022 transition (Knesset 24→25),
-loyalty rates recovered substantially (Shas: 96.9%, UTJ: 95.5%). The recovery indicates that leakage stopped, voters who
-supported these parties remained loyal, not that 23→24 defectors returned. This temporary collapse resembles volatility
-episodes in other democracies where cohesive electorates experience brief but consequential swings, for example, among
-U.S. evangelicals or regional party loyalists in Western Europe. Despite Shas's increased vote share from 7.17% to
-8.25%, this growth originated outside Haredi population hubs, suggesting Shas gained peripheral traditional Sephardic
-supporters while losing core ultra-Orthodox voters to UTJ. The underlying ethnic-political boundaries remained intact
-despite the temporary shock. The pattern is one of **rigidity with occasional stress fractures**, not fluid or liquid
-identity.
+The Results documented a pattern of high baseline stability punctuated by a sharp but temporary disruption in the
+23→24 transition, with geographic variation in magnitude and full recovery by 24→25. This section interprets these
+findings in theoretical and methodological context, exploring what they reveal about ethnic boundary maintenance,
+the conditions under which rigid voting blocs experience disruption, and the implications for measuring residential
+segregation through electoral proxies.
 
 ### Geographic Variation in Disruption Magnitude
 
@@ -259,32 +236,6 @@ This study reveals that ethnic-political boundaries within Israel's ultra-Orthod
 vulnerable — and the evidence presented here is consistent with both their rigidity and their vulnerability deriving
 from the same source: the considerable authority of spiritual leaders over the electoral behavior of hundreds of
 thousands of voters dispersed across the country.
-
-Under normal conditions, this authority appears to sustain near-perfect ethnic-party loyalty: nearly all Sephardic
-Haredim vote for Shas and nearly all Ashkenazi Haredim vote for UTJ, maintaining a clear political expression of ethnic
-differentiation across geographically dispersed communities. These boundaries persist despite — or perhaps because of —
-shared religious observance, communal institutions, and withdrawal from secular society. The near-total consistency of
-voting patterns across distant cities is more consistent with active alignment with rabbinic direction on electoral
-matters than with passive cultural inertia.
-
-The March 2020–March 2021 disruption offers a window into what may happen when that same authority is redirected. A
-handful of rabbinic figures — Mazuz, Barda, several Ashkenazi yeshiva heads — acting in coordination with UTJ's
-political leadership, issued directives that coincided with simultaneous shifts in voting behavior in Jerusalem, Bnei
-Brak, Ashdod, Beit Shemesh, and Modi'in Illit. No campaign infrastructure, no media blitz, no months of grassroots
-organizing preceded these shifts: the corpus documents rabbinic rulings transmitted through yeshiva networks, and the
-quantitative data show a country-wide electoral swing within the same cycle. The equally rapid recovery, once these
-directives were withdrawn or fragmented, is consistent with the interpretation that the population's response reflected
-disciplined compliance with rabbinic authority rather than a spontaneous shift in political preferences — though
-individual voter motivations cannot be observed directly from aggregate data.
-
-The implications extend beyond the Haredi case. In any community where spiritual or institutional authority commands
-strong electoral compliance, the same structures that produce remarkable stability also create a latent capacity for
-rapid, coordinated disruption. The vulnerability is not a weakness in the system of authority but a direct consequence
-of its strength. Whether similar disruptions recur depends on the willingness of rabbinic authorities to issue
-cross-ethnic directives, the institutional overlap created by Sephardi students in Ashkenazi yeshivot, and the
-political circumstances that incentivize inter-party recruitment. The March 2020–March 2021 transition may represent a
-unique confluence of crises unlikely to repeat, or it may expose a structural vulnerability inherent in any
-identity-based electoral system where centralized spiritual authority can override ethnic-party boundaries at will.
 
 What the data clearly show is that assumptions of permanent stability, or conversely, ongoing fluidity, both
 mischaracterize ethnic voting dynamics in cohesive religious communities. The convergence of quantitative and


### PR DESCRIPTION
## Summary

- Replace detailed intro findings preview with brief qualitative summary (cut ~295 words)
- Replace Results "Summary of Findings" numbered list with 4-sentence bridging paragraph (cut ~197 words)
- Delete "High Baseline Stability" subsection from conclusions (restated Results verbatim)
- Cut 3 middle paragraphs from Final Reflections (~60% reduction)
- Tighten conclusions opening paragraph

Main text reduced from 8,617 to 7,543 words (-12.5%).

Closes #5