### PR TITLE
Demote segregation discussion: cut detailed methodology, add brief proxy caveats

### DIFF
--- a/transition_paper/00_abstract.md
+++ b/transition_paper/00_abstract.md
@@ -6,6 +6,4 @@ I exploit a natural experiment, Israel's 2020 - 21 electoral crisis, to track vo
 
 The synchronized switch of voting loyalty across geographically dispersed cities, occurring without residential mobility, is consistent with coordinated elite guidance rather than emerging voter independence. Paradoxically, the capacity for mass switching may reflect stronger, not weaker, institutional control.
 
-This finding exposes a methodological trap. Researchers routinely use voting patterns to measure residential segregation. When voters switched parties without moving, standard indices falsely registered political shifts as spatial integration, a confound that threatens any study conflating demographic and political boundaries.
-
-The broader implication challenges how we interpret electoral behavior in cohesive communities worldwide: apparent volatility may reflect disciplined coordination, and what looks like boundary erosion may actually reveal institutional strength operating through collective action.
+The broader implication challenges how we interpret electoral behavior in cohesive communities worldwide: apparent volatility may reflect disciplined coordination, and what looks like boundary erosion may actually reveal institutional strength operating through collective action. A secondary finding cautions that using party votes as ethnic proxies — common in segregation research — can produce spurious results when elite-driven disruptions decouple voting from demographic patterns.

--- a/transition_paper/01_intro.md
+++ b/transition_paper/01_intro.md
@@ -46,6 +46,8 @@ institutional change occurring during this brief period, the anomaly was puzzlin
 what changed? One plausible answer: politics. Residential segregation changes slowly, but voting behavior can shift
 rapidly. If Sephardi voters temporarily switched from Shas to UTJ (or vice versa), this would create apparent
 "integration" in segregation indices, which rely on party votes as proxies for ethnicity, without any residential movement.
+While this proxy is theoretically grounded and performs well under stable conditions, the Ashdod episode suggests it
+is particularly fragile in highly disciplined populations where centralized authority can rapidly redirect voting behavior.
 This possibility motivated the present study: Was Ashdod's anomaly evidence of a broader, under-the-radar pattern of
 voter transitions within this ostensibly rigid bloc? The period's exceptional political volatility, with four national
 elections between April 2019 and March 2021, provides a natural experiment for testing how electoral shocks affect even
@@ -103,8 +105,7 @@ Specifically, this study contributes by: (1) documenting temporary boundary perm
 disciplined bloc, providing a conservative estimate for volatility in identity-based voting; (2) grounding "rigidity
 with stress fractures" as an analytical framework that synthesizes cleavage theory, volatility typologies, and
 punctuated equilibrium models, specifying the scope conditions under which identity-based blocs experience reversible
-disruption rather than permanent realignment; (3) revealing methodological confounding between political and
-residential measures when loyalty fluctuates; and (4) applying hierarchical Bayesian ecological inference for
+disruption rather than permanent realignment; and (3) applying hierarchical Bayesian ecological inference for
 analyzing voter transitions in cohesive subpopulations. Understanding the conditions
 under which rigid boundaries temporarily yield, and how quickly they reconstitute, is crucial for anticipating coalition
 dynamics and democratic responsiveness in any polity with identity-based voting. The following section details the data

--- a/transition_paper/03_results.md
+++ b/transition_paper/03_results.md
@@ -108,29 +108,11 @@ suggesting that even substantial voter transitions within the Haredi sector can 
 surface of stable electoral outcomes (both parties maintained their coalition positions despite the internal
 reshuffling).
 
-Importantly, while the voter transition disruption was universal across all major Haredi cities, only Ashdod exhibited
-a dramatic drop in residential segregation indices in my previous study (Gorelik, 2025). This city-specific segregation
-response, despite the system-wide voting disruption, proved methodologically revealing. Ashdod's exceptionally high
-switching rate (19.3% compared to 12.3% nationally) apparently crossed a threshold that made the confounding between
-voting patterns and residential segregation visible in the dissimilarity index. This fortunate coincidence, that the city
-with the most extreme switching happened to be the same city where segregation indices were carefully tracked, allowed
-identification of a fundamental measurement issue: using party votes as proxies for ethnic residential patterns can be
-compromised when voter loyalty fluctuates. Had the switching been more uniform across cities, or had Ashdod's rate been
-closer to the national average, this methodological confound might have remained undetected.
-
-## Connection to Residential Segregation Patterns
-
-The 19.3% Shas-to-UTJ switching in Ashdod created apparent "integration" in segregation indices without actual
-residential movement. Ballot boxes previously dominated by Shas (Sephardic) suddenly showed substantial UTJ (Ashkenazi)
-support, reducing the spatial correlation between ethnicity and party vote, precisely what the dissimilarity index
-measures. The synchronized recovery of both voter loyalty (to 96.9% in 24→25) and segregation levels confirms this
-electoral mechanism.
-
-This reveals a critical methodological limitation: using party votes as proxies for ethnic residential patterns assumes
-stable political loyalty. The proxy works well when ethnic-political boundaries are rigid but fails during loyalty
-disruptions. This temporally contingent validity has implications for any study conflating political and demographic
-boundaries, a pattern potentially observable in other contexts where voting behavior proxies for group membership
-(religious denominations, immigrant origin groups, linguistic communities).
+Notably, while the voter transition disruption was universal across all major Haredi cities, only Ashdod exhibited a
+dramatic drop in residential segregation indices in my previous study (Gorelik, 2025). Ashdod's exceptionally high
+switching rate (19.3%) apparently crossed a threshold that made the confounding between voting patterns and residential
+segregation visible in the dissimilarity index, confirming that the anomaly documented in Gorelik (2025) was electoral
+rather than demographic in origin.
 
 ## Other Notable Disruptions Beyond The March 2020–March 2021 Transition
 

--- a/transition_paper/04_conclusions.md
+++ b/transition_paper/04_conclusions.md
@@ -52,26 +52,6 @@ operating independently, the two systems appear to reinforce each other under no
 segregation co-occurs with high political loyalty, creating layered ethnic segmentation. Both spatial and political
 boundaries responded to stress during the 2020 - 2021 period, though with different dynamics and recovery patterns.
 
-### Methodological Revelation: The Confounding of Political and Residential Measures
-
-The dramatic Shas-to-UTJ switching in Ashdod (19.3%) explains the anomalous drop in Ashdod's residential segregation
-index observed in my previous study (Gorelik 2025). When voting patterns changed without residential movement, the
-segregation index, which used party votes as ethnic proxies, falsely registered political switching as residential
-integration.
-
-This exposes a fundamental methodological limitation: using voting patterns to proxy residential segregation assumes stable
-political loyalty. The dissimilarity index confounded ethnic residential clustering with political party loyalty. Any
-future voting disruptions will similarly manifest as apparent "integration" in segregation indices, even when residential
-patterns remain unchanged, a critical consideration for studies conflating political and demographic boundaries.
-
-### Why Only Ashdod Showed Segregation Index Changes
-
-While voter transitions occurred universally across Haredi cities, only Ashdod exhibited detectable segregation index
-changes. Ashdod's combination of extreme switching rates (19.3%) and spatially compact residential segregation made the
-confounding visible. This fortunate coincidence allowed identification of a measurement issue that might otherwise have
-remained hidden, underscoring that confounding visibility depends on both transition magnitude and spatial structure.
-
-
 ## What Caused the 23-24 Disruption?
 
 The timing coincided with extraordinary political and social stress: unprecedented political instability (three elections
@@ -209,26 +189,15 @@ The approach is replicable across other contexts where: - Aggregate data (ballot
 Individual voting patterns are unobserved - Both national trends and local variation are of interest - Multiple time
 periods permit temporal modeling
 
-### Extending Static Segregation Measures to Dynamic Frameworks
-
-By connecting static dissimilarity indices (measuring separation at a point in time) with transition matrices (measuring
-movement over time), this research offers a richer portrait of intra-group segmentation. The combination reveals not
-only that ethnic subgroups maintain distinct residential and political spaces, but also how permeable the boundaries
-between those spaces areand under what conditions permeability increases.
-
-This methodological pairing could be applied to other segmented populations: immigrant communities divided by origin
-region, religious denominations within a shared faith tradition, or linguistic minorities maintaining distinct political
-allegiances. The framework provides a way to quantify both the degree of separation and the rate of exchange between
-subgroups.
-
-
-
 This study focuses on short-term electoral effects and does not address possible social or attitudinal consequences.
 The corpus analysis of Haredi media provides evidence consistent with the elite coordination mechanism but cannot
 quantify individual voter motivations; future research incorporating voter surveys or interviews could further validate the relative weight of
 rabbinic instruction versus personal dissatisfaction. Comparative studies could test whether similar patterns of
 elite-driven 'hidden volatility' appear in other religious or identity-based voting blocs with strong institutional
-structures.
+structures. More broadly, the Ashdod case demonstrates that studies using party votes as proxies for ethnic composition
+should account for the fragility of this assumption in disciplined populations, where elite directives can rapidly
+redirect voting behavior and produce apparent demographic shifts that are purely electoral artifacts (see Gorelik 2025
+for the segregation analysis that first relied on this proxy).
 
 ## Final Reflections
 


### PR DESCRIPTION
## Summary

- Remove "Connection to Residential Segregation Patterns" subsection from results; shorten Ashdod paragraph with Gorelik 2025 reference
- Remove "Methodological Revelation" and "Extending Static Segregation" subsections from conclusions
- Add brief proxy fragility caveat in intro (Ashdod narrative) and conclusions (limitations)
- Reduce contributions list from 4 to 3 items (drop segregation proxy confound)
- Soften abstract: demote proxy confound from standalone paragraph to brief closing sentence

No appendix created — segregation methodology already published in Gorelik 2025; readers referred there instead.

Main text: 7,107 words (down from 7,543).

Closes #6